### PR TITLE
Implement DB init and repository CRUD

### DIFF
--- a/base/core/repository.py
+++ b/base/core/repository.py
@@ -9,3 +9,55 @@ from attrs import define, field
 class Repository:
     outlines: Dict[str, Any] = field(factory=dict)
     tools: Dict[str, Any] = field(factory=dict)
+
+    # Outline CRUD methods
+    def add_outline(self, name: str, outline: Any) -> None:
+        """Store a new outline."""
+
+        self.outlines[name] = outline
+
+    def get_outline(self, name: str) -> Any | None:
+        """Retrieve an outline by name."""
+
+        return self.outlines.get(name)
+
+    def update_outline(self, name: str, outline: Any) -> None:
+        """Update or create an outline."""
+
+        self.outlines[name] = outline
+
+    def delete_outline(self, name: str) -> None:
+        """Remove an outline if present."""
+
+        self.outlines.pop(name, None)
+
+    def list_outlines(self) -> list[str]:
+        """Return the names of all stored outlines."""
+
+        return list(self.outlines)
+
+    # Tool CRUD methods
+    def add_tool(self, name: str, tool: Any) -> None:
+        """Store a new tool."""
+
+        self.tools[name] = tool
+
+    def get_tool(self, name: str) -> Any | None:
+        """Retrieve a tool by name."""
+
+        return self.tools.get(name)
+
+    def update_tool(self, name: str, tool: Any) -> None:
+        """Update or create a tool."""
+
+        self.tools[name] = tool
+
+    def delete_tool(self, name: str) -> None:
+        """Remove a tool if present."""
+
+        self.tools.pop(name, None)
+
+    def list_tools(self) -> list[str]:
+        """Return the names of all stored tools."""
+
+        return list(self.tools)

--- a/base/core/storage.py
+++ b/base/core/storage.py
@@ -1,9 +1,13 @@
-from sqlmodel import Session, create_engine
+from sqlmodel import Session, SQLModel, create_engine
 
 from base import settings
 
 engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI))
 
 
-def init_db(session: Session):
-    pass
+def init_db(session: Session) -> None:
+    """Initialise the database tables."""
+
+    # SQLModel collects metadata for all model classes. Calling ``create_all``
+    # will create any tables that do not already exist.
+    SQLModel.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- create tables with SQLModel in `init_db`
- add CRUD helpers for outlines and tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fe31de708331a6ba24fdf43bd035