### PR TITLE
Add instruction set JSON and docs

### DIFF
--- a/config/instructions.json
+++ b/config/instructions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "default",
+    "content": "You are a helpful assistant. Keep responses short and direct."
+  },
+  {
+    "name": "friendly",
+    "content": "You are a friendly assistant who engages in casual conversation while providing useful information."
+  }
+]

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,0 +1,14 @@
+# Instructions Format
+
+Instructions for the library live in `config/instructions.json`. The file is a JSON array where each object provides the instruction text for a given name.
+
+```json
+[
+  {
+    "name": "default",
+    "content": "You are a helpful assistant. Keep responses short and direct."
+  }
+]
+```
+
+Use `load_instructions(name)` to retrieve the `content` for a matching `name`.


### PR DESCRIPTION
## Summary
- add `config/instructions.json` with initial instruction entries
- document the format in `docs/instructions.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fe3255f08331b34fdfd02f021d4e