### PR TITLE
Fix metadata method definition

### DIFF
--- a/base/core/context.py
+++ b/base/core/context.py
@@ -23,7 +23,15 @@ class Metadata:
     summary: str = field(default=None)
     embedding: List[float] = field(default=None)
 
+    @classmethod
     async def metadata(cls):
+        """Generate and parse metadata for the current context.
+
+        The method assumes ``cls.render`` produces the text representation of
+        the conversation and ``cls.serialize`` yields a JSON schema describing
+        :class:`Metadata`. The ``generate`` helper returns an object whose
+        ``output`` contains JSON fragments that can be loaded into this class.
+        """
         res = await generate(
             input=f"Generate concise, intelligent, semantically-rich metadata for the following thread:\n\n{await cls.render()}",
             text={"format": cls.serialize(Metadata)},


### PR DESCRIPTION
## Summary
- clarify that `Metadata.metadata` is a class method
- document how metadata is generated and parsed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fe32eb448331993ab75bac648dcd