### PR TITLE
Fix serialize helper signature

### DIFF
--- a/base/core/context.py
+++ b/base/core/context.py
@@ -6,6 +6,7 @@ from typing import List
 from attrs import define, field
 
 from base.core.classify import generate
+from base.helpers import serialize
 from base.schema.messages import Content
 
 SIMILARITY_THRESHOLD = 0.85
@@ -26,7 +27,7 @@ class Metadata:
     async def metadata(cls):
         res = await generate(
             input=f"Generate concise, intelligent, semantically-rich metadata for the following thread:\n\n{await cls.render()}",
-            text={"format": cls.serialize(Metadata)},
+            text={"format": serialize(Metadata)},
             model="gpt-4.1",
         )
 

--- a/base/helpers.py
+++ b/base/helpers.py
@@ -162,7 +162,7 @@ def _type_schema(cls):
     }
 
 
-def serialize(self, obj: Any):
+def serialize(obj: Any):
     if inspect.isfunction(obj):
         return {
             "type": "function",


### PR DESCRIPTION
## Summary
- adjust `serialize` helper to no longer take a `self` argument
- update usage in `context` module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848fe34caa48331a833e58c9e2961ed