### PR TITLE
Fix schema import paths

### DIFF
--- a/base/schema/tasks.py
+++ b/base/schema/tasks.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from attrs import define, field
 
-from base.core.schemas.messages import Content, Instructions
+from base.schema.messages import Content, Instructions
 
 
 @define

--- a/base/schema/threads.py
+++ b/base/schema/threads.py
@@ -7,8 +7,8 @@ from typing import Callable, List, Optional
 from attrs import define, field
 
 from base.core.helpers import timestamp
-from base.core.schemas.context import Metadata
-from base.core.schemas.messages import Content
+from base.schema.context import Metadata
+from base.schema.messages import Content
 
 
 THREAD_TIMEOUT = timedelta(minutes=30)


### PR DESCRIPTION
## Summary
- correct imports in `tasks.py` and `threads.py`
- use `base.schema` as import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fe3543d083318163a55107ad85d7