### PR TITLE
Fix API router import

### DIFF
--- a/base/api/main.py
+++ b/base/api/main.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter
 
-from base.api.routes import ingest, retrieve
+from base.api import routes
 
 api_router = APIRouter()
-api_router.include_router(ingest.router)
-api_router.include_router(retrieve.router)
+api_router.include_router(routes.router)

--- a/base/api/routes.py
+++ b/base/api/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from base.api.schema import IngestRequest, QueryRequest
+from base.schema.requests import IngestRequest, QueryRequest
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary
- fix import for FastAPI routes
- register router via `routes.router`
- align schema imports for route definitions

## Testing
- `python -m py_compile base/api/main.py base/api/routes.py base/api/schema.py base/main.py base/schema/requests.py`
- `pyright` *(fails: Import "base.core.schemas.messages" could not be resolved)*
- `python - <<'PY'
from base.api.main import api_router
from fastapi import FastAPI
app = FastAPI()
app.include_router(api_router)
print([r.path for r in app.router.routes])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6848fe37afec8331a5f1bd71004e7bb5